### PR TITLE
New Exit Nodes

### DIFF
--- a/proxpn
+++ b/proxpn
@@ -79,18 +79,19 @@ PORT=443
 
 # Hosts provided per ProXPN customer support, spring 2015
 declare -A EXIT_NODES
-EXIT_NODES[Miami]=mfl1.proxpn.com
-EXIT_NODES[NYC]=ny1.proxpn.com
 EXIT_NODES[Dallas]=d1.proxpn.com
-EXIT_NODES[Seattle]=se1.proxpn.com
+EXIT_NODES[NYC]=ny1.proxpn.com
+EXIT_NODES[Miami]=mfl1.proxpn.com
 EXIT_NODES[Chicago]=chi1.proxpn.com
+EXIT_NODES[Seattle]=se1.proxpn.com
 EXIT_NODES[LA]=la1.proxpn.com
-EXIT_NODES[Sweden]=swe1.proxpn.com
-EXIT_NODES[UK]=uk1.proxpn.com
 EXIT_NODES[Netherlands]=nl1.proxpn.com
-EXIT_NODES[Czech]=cz1.proxpn.com
 EXIT_NODES[Singapore]=sg1.proxpn.com
+EXIT_NODES[London]=uk1.proxpn.com
+EXIT_NODES[Prague]=cz1.proxpn.com
 EXIT_NODES[Stockholm]=swe1.proxpn.com
+EXIT_NODES[SanJose]=openvpn-cr.proxpn.com
+EXIT_NODES[Sweden]=swe1.proxpn.com
 
 # ProXPN basic account exit nodes actually send
 # users to many geo locations so there's no reason

--- a/proxpn
+++ b/proxpn
@@ -83,12 +83,14 @@ EXIT_NODES[Miami]=mfl1.proxpn.com
 EXIT_NODES[NYC]=ny1.proxpn.com
 EXIT_NODES[Dallas]=d1.proxpn.com
 EXIT_NODES[Seattle]=se1.proxpn.com
+EXIT_NODES[Chicago]=chi1.proxpn.com
 EXIT_NODES[LA]=la1.proxpn.com
 EXIT_NODES[Sweden]=swe1.proxpn.com
 EXIT_NODES[UK]=uk1.proxpn.com
 EXIT_NODES[Netherlands]=nl1.proxpn.com
 EXIT_NODES[Czech]=cz1.proxpn.com
 EXIT_NODES[Singapore]=sg1.proxpn.com
+EXIT_NODES[Stockholm]=swe1.proxpn.com
 
 # ProXPN basic account exit nodes actually send
 # users to many geo locations so there's no reason


### PR DESCRIPTION
This PR adds new exit nodes, as pointed out by #2 , though it seems like for all the servers listed on [ProXPN's server list](http://www.proxpn.com/updater/locations-v2.xml) only Chicago and Stockholm seem to have DNS setup using their standard pattern. I'd prefer not to put magic IP addresses in this script to be sensitive to the security of the folks who are using it. Likewise I'd like to avoid needing to contact ProXPN's server to get the list of valid exit nodes.

```
dig swe1.proxpn.com

; <<>> DiG 9.10.3 <<>> swe1.proxpn.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 6774
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;swe1.proxpn.com.       IN  A

;; ANSWER SECTION:
swe1.proxpn.com.    14400   IN  A   94.185.84.34
```

```
dig chi1.proxpn.com

; <<>> DiG 9.10.3 <<>> chi1.proxpn.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 64157
;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;chi1.proxpn.com.       IN  A

;; ANSWER SECTION:
chi1.proxpn.com.    14400   IN  A   50.7.1.243
```

But for Montreal:

```
dig mtl1.proxpn.com

; <<>> DiG 9.10.3 <<>> mtl1.proxpn.com
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 64952
;; flags: qr aa rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;mtl1.proxpn.com.       IN  A
```

To Do:
- [ ] Figure out what's up with domains for all new exit nodes.
