### PR TITLE
Hotfix quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ brew install Caskroom/cask/tuntap
 
 ### Installing This Script
 
-To use this script you can either clone this repo, or download the source from the releases page.
+To use this script you can either clone this repo, or download the source from the [releases page](https://github.com/MattSurabian/proxpn-bash-client/releases).
 
 The following process, can now all be done using the provided installation script: `sudo ./install.sh`
 If you would prefer to do it manually, here are the steps:

--- a/proxpn
+++ b/proxpn
@@ -144,7 +144,7 @@ fi
 
 # Store the command we're about to run in a variable and use the auth-nocache option
 # to ensure OpenVPN doesn't attempt to cache auth information in memory
-COMMAND="$OPENVPN --config \"$OPENVPN_CONF\" --remote \"$remote\" $PORT --auth-user-pass \"$AUTH_CREDS\" --auth-nocache"
+COMMAND="$OPENVPN --config $OPENVPN_CONF --remote $remote $PORT --auth-user-pass $AUTH_CREDS --auth-nocache"
 
 # If we're in dry-run mode then print the command and exit
 if [ $dryRun = true ]; then

--- a/proxpn
+++ b/proxpn
@@ -144,7 +144,7 @@ fi
 
 # Store the command we're about to run in a variable and use the auth-nocache option
 # to ensure OpenVPN doesn't attempt to cache auth information in memory
-COMMAND="$OPENVPN --config $OPENVPN_CONF --remote $remote $PORT --auth-user-pass $AUTH_CREDS --auth-nocache"
+COMMAND="$OPENVPN --config $OPENVPN_CONF --remote $remote $PORT --auth-nocache --auth-user-pass $AUTH_CREDS"
 
 # If we're in dry-run mode then print the command and exit
 if [ $dryRun = true ]; then


### PR DESCRIPTION
Turns out even though copying and pasting an openvpn command with quoted arguments is valid, it's not valid when that command is stored in a string and run.
